### PR TITLE
Fixed. NoMethodError when photo is not found

### DIFF
--- a/lib/cure_line/post.rb
+++ b/lib/cure_line/post.rb
@@ -46,7 +46,7 @@ module CureLine
 
     # @return [Array<Hash>]
     def medias
-      dig("post", "contents", "media")
+      dig("post", "contents", "media") || []
     end
   end
 end

--- a/spec/cure_line/post_spec.rb
+++ b/spec/cure_line/post_spec.rb
@@ -1,7 +1,8 @@
 RSpec.describe CureLine::Post do
   let(:post) { CureLine::Post.new(feed_hash) }
 
-  let(:feed_hash) { preloaded_state["userHome"]["feeds"][0] }
+  let(:feed_hash)  { preloaded_state["userHome"]["feeds"][feed_index] }
+  let(:feed_index) { 0 }
 
   let(:preloaded_state) do
     CureLine::Mash.new(JSON.parse(fixture("user.json")))
@@ -74,5 +75,11 @@ RSpec.describe CureLine::Post do
 
     its(:count) { should eq 1 }
     its([0]) { should eq "https://obs.line-scdn.net/h5XG4_2KndnZXIWV4GHdxDwZTY0ZUe34iR3snQghNNkNUfSx0Qy4lRF9PPERUeS8iQy9gFwtOYENTfg" }
+
+    context "When photo is not found" do
+      let(:feed_index) { 5 }
+
+      it { should eq [] }
+    end
   end
 end


### PR DESCRIPTION
```
NoMethodError: private method `select' called for nil:NilClass
./lib/cure_line/post.rb:44:in `photo_urls'
./spec/cure_line/post_spec.rb:74:in `block (3 levels) in <top (required)>'
./spec/cure_line/post_spec.rb:82:in `block (4 levels) in <top (required)>'
```