### PR TITLE
[Resolved] Deprecated warning on Ruby 2.7

### DIFF
--- a/lib/cure_line/user.rb
+++ b/lib/cure_line/user.rb
@@ -39,7 +39,7 @@ module CureLine
       options["User-Agent"] = CureLine.config.user_agent if CureLine.config.user_agent
 
       url = "https://timeline.line.me/user/#{user_id}"
-      html = open(url, options).read
+      html = URI.open(url, options).read
 
       m = html.match(%r{<script id="init_data" type="application/json">({.+})</script>})
       raise %Q(Not Found <script id="init_data" type="application/json"> in #{url}) unless m


### PR DESCRIPTION
```
warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open 
```

https://github.com/sue445/cure_line/runs/369757308