### PR TITLE
Drop support ruby 2.3 and 2.4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,11 @@ jobs:
 
       matrix:
         ruby:
-          - 2.3.0
-          - 2.4.0
           - 2.5.0
           - 2.6.0
           - 2.7.0
           - 2.8.0-dev
         include:
-          - ruby: 2.3.0
-            runner: ubuntu-16.04
-          - ruby: 2.4.0
-            runner: ubuntu-latest
           - ruby: 2.5.0
             runner: ubuntu-latest
           - ruby: 2.6.0

--- a/cure_line.gemspec
+++ b/cure_line.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/sue445/cure_line"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.5.0"
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})


### PR DESCRIPTION
`URI.open` is available since ruby 2.5

ref #18