### PR TITLE
[Resolved] deprecation warinng on Ruby 2.7

### DIFF
--- a/cure_line.gemspec
+++ b/cure_line.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", ">= 1.16"
   spec.add_development_dependency "coveralls"
   spec.add_development_dependency "pry-byebug"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-its"
   spec.add_development_dependency "simplecov"


### PR DESCRIPTION
```
$ be rake -T
/Users/sue445/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/rake-10.5.0/lib/rake/application.rb:381: warning: deprecated Object#=~ is called on Proc; it always returns nil
```